### PR TITLE
Workaround for empty assembly version on Mono for net framework projects

### DIFF
--- a/git-commit-to-assembly-title/Vostok.Tools.GitCommit2AssemblyTitle.props
+++ b/git-commit-to-assembly-title/Vostok.Tools.GitCommit2AssemblyTitle.props
@@ -12,6 +12,9 @@
   <UsingTask TaskName="Vostok.Tools.GitCommit2AssemblyTitle.GitCommit2AssemblyTitle" AssemblyFile="$(TaskAssembly)" />
 
   <Target Name="GenerateAssemblyTitle" BeforeTargets="BeforeBuild">
+    <PropertyGroup Condition="'$(Version)' == ''">
+      <Version>1.0.0.0</Version>
+    </PropertyGroup>
     <GitCommit2AssemblyTitle AssemblyVersion="$(Version)"/>
   </Target>
 


### PR DESCRIPTION
Set Version variable to default value (as it's done on Windows) if it's empty. 