### PR TITLE
Add support for explicit nuget package name hint in assembly reference

### DIFF
--- a/dotnetcementrefs/dotnetcementrefs.csproj
+++ b/dotnetcementrefs/dotnetcementrefs.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>Latest</LangVersion>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <Authors>Vostok team</Authors>
     <Product>dotnetcementrefs</Product>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
Right now, the logic of converting assembly reference to package reference is very simple, it's a 1:1 mapping of assembly name to the package name.

This is not always true or convenient (some packages have multiple assemblies, and there might be multiple packages containing overlapping subsets of the assemblies).

This PR adds support for a custom hint element to annotate what package to use during replacement process. The element name is `NugetPackageName`, which shouldn't conflict with anything.

Example:
```xml
<Reference Include="Some.Client">
  <NugetPackageName>Some.Client.Full</NugetPackageName>
  <HintPath>..\..\some-project\Client\bin\Release\Some.Client.dll</HintPath>
</Reference>
```
this will be replaced with
```xml
<PackageReference Include="Some.Client.Full"/>
```

There's also new logic to reference each nuget package only once per `ItemGroup` as opposed to the current logic of replacing each assembly reference unconditionally.

This commit also bumps minor version for the tool.