### PR TITLE
Fix prerelease version selection from nuget api results

### DIFF
--- a/dotnetcementrefs/dotnetcementrefs.cs
+++ b/dotnetcementrefs/dotnetcementrefs.cs
@@ -327,8 +327,11 @@ public static class Program
         var maxVer = versions.Max();
         // semver doesn't sort suffix numerically, so .Max() will return the oldest prerelease version
         // there could be a better solution with proper string comparer,
-        // but it'll only help if all prerelease versions have the same tag name with numbered suffix 
-        var latest = versions.Last(v => v.Version == maxVer.Version);
+        // but it'll only help if all prerelease versions have the same tag name with numbered suffix
+        // additionally, if there's a release version available, it must be the most relevant one
+        // even if there are later prerelease versions published after it
+        var latest = versions.LastOrDefault(v => v.Version == maxVer.Version && !v.IsPrerelease)
+            ?? versions.Last(v => v.Version == maxVer.Version);
         return latest;
     }
 

--- a/dotnetcementrefs/dotnetcementrefs.cs
+++ b/dotnetcementrefs/dotnetcementrefs.cs
@@ -308,19 +308,28 @@ public static class Program
         var packageSource = new PackageSource(sourceUrl);
         var sourceRepository = new SourceRepository(packageSource, providers);
         var metadataResource = sourceRepository.GetResource<PackageMetadataResource>();
-        var versions = (
-                await metadataResource.GetMetadataAsync(
-                    package,
-                    includePrerelease,
-                    false,
-                    new(),
-                    new NullLogger(),
-                    CancellationToken.None
-                ).ConfigureAwait(false)
-            ).Where(data => data.Identity.Id == package)
+        var searchResult = await metadataResource.GetMetadataAsync(
+            package,
+            includePrerelease,
+            false,
+            new(),
+            new NullLogger(),
+            CancellationToken.None
+        ).ConfigureAwait(false);
+        var versions = searchResult 
+            .Where(data => data.Identity.Id == package)
+            .OrderBy(data => data.Published)
             .Select(data => data.Identity.Version)
             .ToArray();
-        return versions.Any() ? versions.Max() : null;
+        if (versions.Length == 0)
+            return null;
+        
+        var maxVer = versions.Max();
+        // semver doesn't sort suffix numerically, so .Max() will return the oldest prerelease version
+        // there could be a better solution with proper string comparer,
+        // but it'll only help if all prerelease versions have the same tag name with numbered suffix 
+        var latest = versions.Last(v => v.Version == maxVer.Version);
+        return latest;
     }
 
     private class Parameters


### PR DESCRIPTION
Current logic selects the _oldest_ prerelease version, which is not ideal.

Example (asuming versions are listed in order of publish date):
* `1.0.0-rc6`
* `1.0.0-rc16`
would result in `1.0.0-rc6` being selected before, and `1.0.0-rc16` being selected after changes

Another example to consider:
* `1.0.0-latest-alpha`
* `1.0.0-beta`
similar issue, it would select `latest-alpha` before, and `beta` after these changes.